### PR TITLE
[feat] Update public signature to permit config

### DIFF
--- a/cmd/mokku/mokku.go
+++ b/cmd/mokku/mokku.go
@@ -23,7 +23,7 @@ func main() {
 		errorOut(err)
 	}
 
-	mock, err := mokku.Mock([]byte(s))
+	mock, err := mokku.Mock(mokku.Config{}, []byte(s))
 	if err != nil {
 		errorOut(err)
 	}

--- a/mokku.go
+++ b/mokku.go
@@ -2,9 +2,17 @@ package mokku
 
 import "go/format"
 
+// Config is currently ignored but is expected to contain various configuration
+// options for this tool given by user-provided flags in the future.
+type Config struct {
+	// Intentionally empty at the moment.
+	// Included only to avoid breaking backwards compatibility if a newer
+	// version of the package supports new features
+}
+
 // Mock creates the sourcecode of a mock implementation of the interface
 // sourcecode defined in the given byte array.
-func Mock(src []byte) ([]byte, error) {
+func Mock(_ Config, src []byte) ([]byte, error) {
 	target, err := newParser(src).parse()
 	if err != nil {
 		return nil, err

--- a/mokku_test.go
+++ b/mokku_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestIntegration(t *testing.T) {
-	got, err := mokku.Mock([]byte(`
+	got, err := mokku.Mock(mokku.Config{}, []byte(`
     type Foo interface {
 		Act()
 	}`))


### PR DESCRIPTION
In the future mokku is likely to support different options (e.g. whether
or not to include godocs on the generated type, make mocks safe for
concurrent access, whether or not to store the arguments per call to a
mocked method, etc.).
In order to not having to break backwards compatibility (even before
v1.x.x) this commit identifies the desired signature upfront.