### PR TITLE
feature: support template load feature

### DIFF
--- a/template.go
+++ b/template.go
@@ -2,7 +2,13 @@ package mokku
 
 import (
 	"bytes"
+	"io/ioutil"
+	"os"
 	"text/template"
+)
+
+const (
+	mokkuTemplatePathEnvName = "MOKKU_TEMPLATE_PATH"
 )
 
 const tpl = `
@@ -19,7 +25,19 @@ type {{.TypeName}}Mock struct { {{ range .Methods }}
 {{ end }}{{ end }}`
 
 func mockFromTemplate(defn *targetInterface) ([]byte, error) {
-	tmpl, err := template.New("mock").Parse(tpl)
+	// set default template to source template
+	src := tpl
+
+	p := os.Getenv(mokkuTemplatePathEnvName)
+	if p != "" {
+		// if succeeding to read from the file,
+		// set to source template
+		if b, err := ioutil.ReadFile(p); err == nil {
+			src = string(b)
+		}
+	}
+
+	tmpl, err := template.New("mock").Parse(src)
 	if err != nil {
 		return nil, err
 	}

--- a/testdata/test.tpl
+++ b/testdata/test.tpl
@@ -1,0 +1,4 @@
+
+type {{.TypeName}}Mock struct { {{ range .Methods }}
+	{{.Name}}Func func{{.Signature}}{{ end }}
+}


### PR DESCRIPTION
## WHAT
Currently, template is fixed and built in the mokku binary.
However, people want to follow their rule of project, policy, preferable, and so on.
This suggestion is to support loading the template from the given environment variable.

I supposed to use with .envrc etc.