### PR TITLE
Next release

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,27 @@ func RegisterUser(userName string, repo UserRepository) {
 }
 ```
 
+### Defining Custom Templates
+
+You can also define your own custom template to use for your mocks, by defining `MOKKU_TEMPLATE_PATH` that is the path to a file containing a Go text template, that uses the same variables found in the default template:
+
+```go
+const defaultTemplate = `
+type {{.TypeName}}Mock struct { {{ range .Methods }}
+	{{.Name}}Func func{{.Signature}}{{ end }}
+}
+{{if .Methods }}{{$typeName := .TypeName}}
+{{range $val := .Methods}}func (m *{{$typeName}}Mock) {{$val.Name}}{{$val.Signature}} {
+	if m.{{$val.Name}}Func == nil {
+		panic("unexpected call to {{$val.Name}}")
+	}
+	{{if $val.HasReturn}}return {{ end }}m.{{$val.Name}}Func{{$val.OrderedParams}}
+}
+{{ end }}{{ end }}`
+```
+
+[See the GoDocs](https://pkg.go.dev/github.com/kinbiko/mokku?tab=doc) for a more detailed explanation of the template variables.
+
 ## Contributing
 
 Please raise an issue to discuss any changes you'd like to make to this project.

--- a/cmd/mokku/mokku.go
+++ b/cmd/mokku/mokku.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"os"
 
 	"github.com/atotto/clipboard"
@@ -14,16 +16,39 @@ const usage = `Usage:
 2. Run 'mokku'
 3. Paste the mocked implementation that has been written to your clipboard`
 
+const defaultTemplate = `
+type {{.TypeName}}Mock struct { {{ range .Methods }}
+	{{.Name}}Func func{{.Signature}}{{ end }}
+}
+{{if .Methods }}{{$typeName := .TypeName}}
+{{range $val := .Methods}}func (m *{{$typeName}}Mock) {{$val.Name}}{{$val.Signature}} {
+	if m.{{$val.Name}}Func == nil {
+		panic("unexpected call to {{$val.Name}}")
+	}
+	{{if $val.HasReturn}}return {{ end }}m.{{$val.Name}}Func{{$val.OrderedParams}}
+}
+{{ end }}{{ end }}`
+
 func main() {
 	flag.Usage = func() { fmt.Println(usage) }
+	templateName := flag.String("t", "", "TemplateFile")
 	flag.Parse()
+
+	templateStr := defaultTemplate
+	if *templateName != "" {
+		var err error
+		templateStr, err = loadTemplate(*templateName)
+		if err != nil {
+			errorOut(err)
+		}
+	}
 
 	s, err := clipboard.ReadAll()
 	if err != nil {
 		errorOut(err)
 	}
 
-	mock, err := mokku.Mock(mokku.Config{}, []byte(s))
+	mock, err := mokku.Mock(mokku.Config{TemplateStr: templateStr}, []byte(s))
 	if err != nil {
 		errorOut(err)
 	}
@@ -31,6 +56,16 @@ func main() {
 	if err = clipboard.WriteAll(string(mock)); err != nil {
 		errorOut(err)
 	}
+}
+
+// loadTemplate loads template string from filePath
+func loadTemplate(filePath string) (string, error) {
+	content, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return "", errors.New(fmt.Sprintf("failed to read file %s: %v", filePath, err))
+	}
+	templateStr := string(content)
+	return templateStr, nil
 }
 
 func errorOut(err error) {

--- a/mokku.go
+++ b/mokku.go
@@ -8,16 +8,19 @@ type Config struct {
 	// Intentionally empty at the moment.
 	// Included only to avoid breaking backwards compatibility if a newer
 	// version of the package supports new features
+
+	// TemplateStr is mock template string
+	TemplateStr string
 }
 
 // Mock creates the sourcecode of a mock implementation of the interface
 // sourcecode defined in the given byte array.
-func Mock(_ Config, src []byte) ([]byte, error) {
+func Mock(config Config, src []byte) ([]byte, error) {
 	target, err := newParser(src).parse()
 	if err != nil {
 		return nil, err
 	}
-	mft, err := mockFromTemplate(target)
+	mft, err := mockFromTemplate(target, config.TemplateStr)
 	if err != nil {
 		return nil, err
 	}

--- a/mokku.go
+++ b/mokku.go
@@ -2,14 +2,17 @@ package mokku
 
 import "go/format"
 
-// Config is currently ignored but is expected to contain various configuration
-// options for this tool given by user-provided flags in the future.
+// Config is defines all configuration options for mokku.
+// In particular, this package treats additions to this struct as *non-breaking* changes.
 type Config struct {
-	// Intentionally empty at the moment.
-	// Included only to avoid breaking backwards compatibility if a newer
-	// version of the package supports new features
-
-	// TemplateStr is mock template string
+	// TemplateStr is mock template string.
+	// The template will attempt to fill in the following fields:
+	//  TypeName -- string. E.g. "MyInterface"
+	//	Methods  -- composite type containing:
+	//		Name			-- string. E.g. "DoStuff"
+	//		Signature		-- string. E.g. "(a, b int) error"
+	//		OrderedParams	-- string. E.g. "(a, b)"
+	//		HasReturn		-- bool. Identifies whether or not the mocked method should return anything.
 	TemplateStr string
 }
 

--- a/mokku_test.go
+++ b/mokku_test.go
@@ -7,7 +7,20 @@ import (
 )
 
 func TestIntegration(t *testing.T) {
-	got, err := mokku.Mock(mokku.Config{}, []byte(`
+	const templateStr = `
+type {{.TypeName}}Mock struct { {{ range .Methods }}
+	{{.Name}}Func func{{.Signature}}{{ end }}
+}
+{{if .Methods }}{{$typeName := .TypeName}}
+{{range $val := .Methods}}func (m *{{$typeName}}Mock) {{$val.Name}}{{$val.Signature}} {
+	if m.{{$val.Name}}Func == nil {
+		panic("unexpected call to {{$val.Name}}")
+	}
+	{{if $val.HasReturn}}return {{ end }}m.{{$val.Name}}Func{{$val.OrderedParams}}
+}
+{{ end }}{{ end }}`
+
+	got, err := mokku.Mock(mokku.Config{TemplateStr: templateStr}, []byte(`
     type Foo interface {
 		Act()
 	}`))

--- a/template.go
+++ b/template.go
@@ -5,21 +5,8 @@ import (
 	"text/template"
 )
 
-const tpl = `
-type {{.TypeName}}Mock struct { {{ range .Methods }}
-	{{.Name}}Func func{{.Signature}}{{ end }}
-}
-{{if .Methods }}{{$typeName := .TypeName}}
-{{range $val := .Methods}}func (m *{{$typeName}}Mock) {{$val.Name}}{{$val.Signature}} {
-	if m.{{$val.Name}}Func == nil {
-		panic("unexpected call to {{$val.Name}}")
-	}
-	{{if $val.HasReturn}}return {{ end }}m.{{$val.Name}}Func{{$val.OrderedParams}}
-}
-{{ end }}{{ end }}`
-
-func mockFromTemplate(defn *targetInterface) ([]byte, error) {
-	tmpl, err := template.New("mock").Parse(tpl)
+func mockFromTemplate(defn *targetInterface, templateStr string) ([]byte, error) {
+	tmpl, err := template.New("mock").Parse(templateStr)
 	if err != nil {
 		return nil, err
 	}

--- a/template_test.go
+++ b/template_test.go
@@ -18,13 +18,10 @@ type {{.TypeName}}Mock struct { {{ range .Methods }}
 }
 {{ end }}{{ end }}`
 
-	type args struct {
-	}
 	for _, tc := range []struct {
-		name        string
-		defn        *targetInterface
-		templateStr string
-		exp         string
+		name string
+		in   *targetInterface
+		exp  string
 	}{
 		{
 			name: "basic case",
@@ -32,8 +29,7 @@ type {{.TypeName}}Mock struct { {{ range .Methods }}
 type Mock struct { 
 }
 `,
-			defn:        &targetInterface{},
-			templateStr: templateStr,
+			in: &targetInterface{},
 		},
 
 		{
@@ -65,7 +61,7 @@ func (m *FooBarMock) NoReturnParam( a string ) {
 }
 `,
 
-			defn: &targetInterface{
+			in: &targetInterface{
 				TypeName: "FooBar",
 				Methods: []*method{
 					{Name: "Act", Signature: "( ) error", OrderedParams: "( )", HasReturn: true},
@@ -73,11 +69,10 @@ func (m *FooBarMock) NoReturnParam( a string ) {
 					{Name: "NoReturnParam", Signature: "( a string )", OrderedParams: "( a )", HasReturn: false},
 				},
 			},
-			templateStr: templateStr,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			b, err := mockFromTemplate(tc.defn, tc.templateStr)
+			b, err := mockFromTemplate(tc.in, templateStr)
 			if err != nil {
 				t.Fatalf("unexpected error: %s", err.Error())
 			}


### PR DESCRIPTION
This next release enables users to specify their own template for mocks with the `MOKKU_TEMPLATE_PATH` environment variable.