### PR TITLE
fix: allow trailing comma in method signature

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -194,7 +194,9 @@ func parseArgs(src string) string {
 			if lit == "" {
 				lit = tok.String()
 			}
-			collect = append(collect, lit)
+			if lit != ")" {
+				collect = append(collect, lit)
+			}
 		}
 		switch tok {
 		case token.COMMA:

--- a/parser_test.go
+++ b/parser_test.go
@@ -86,6 +86,20 @@ func TestParser(t *testing.T) {
 		},
 
 		{
+			name: "trailing comma",
+			src: `type Calculator interface {
+				Add(
+					a int,
+					b int,
+				) int
+			}`,
+			exp: &targetInterface{
+				TypeName: "Calculator",
+				Methods:  []*method{{"Add", `( a int , b int , ) int`, `( a , b , )`, true}},
+			},
+		},
+
+		{
 			name: "mega complex example",
 			src: `type GoodLuck interface {
 				First()


### PR DESCRIPTION
Allow for trailing commas in interface method signatures.

Until this change, this will fail as it adds an excessive `)` character, which cannot be processed.

Closes #25.

## Checklist

- [x] I have done a self-review of the PR.
